### PR TITLE
Userstory7

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,28 +1,31 @@
 class ReviewsController < ApplicationController
   def new
     @shelter = Shelter.find(params[:id])
-
-    # @user = User.find(params[:id])
   end
 
   def create
     @shelter = Shelter.find(params[:shelter_id])
-    review = Review.new({title: params[:title],
-                        rating: params[:rating],
-                        content: params[:content],
-                        name_of_user: params[:name_of_user],
-                        user_id: params[:user_id],
-                        shelter_id: params[:shelter_id]}
-                      )
+    review = Review.new(review_params)
     review.save
-  
     redirect_to "/shelters/#{@shelter.id}"
   end
 
+  def edit
+    @review = Review.find(params[:id])
+  end
 
-  # private
-  #
-  # def review_params
-  #   params.permit(:id, :title, :rating, :content, :picture, :name_of_user, shelter_id: params[:shelter_id], :user_id)
-  # end
+  def update
+    review = Review.find(params[:review_id])
+      review.update(review_params)
+      review.save
+    redirect_to "/shelters/#{review.shelter_id}"
+  end
+
+
+  private
+
+  def review_params
+    params.permit(:id, :title, :rating, :content, :picture, :name_of_user, :shelter_id, :user_id)
+  end
+
 end

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Edit Review:</h2>
+<div class="show">
+<%= form_tag "/shelters/#{@review.shelter_id}/review/#{@review.id}", method: :patch do %>
+
+<%= label_tag :title %>
+<%= text_field_tag :title, value="#{@review.title}" %><br>
+
+<%= label_tag :rating %>
+<%= text_field_tag :rating, value="#{@review.rating}" %><br>
+
+<%= label_tag :content  %>
+<%= text_field_tag :content, value="#{@review.content}" %><br>
+
+<%= label_tag :picture %>
+<%= text_field_tag :picture, value="#{@review.picture}" %><br>
+
+<%= label_tag :username %>
+<%= text_field_tag :name_of_user, value="#{@review.name_of_user}" %><br>
+
+<%= label_tag :user_id %>
+<%= text_field_tag :user_id, value="#{@review.user_id}" %><br>
+
+<%= submit_tag "Update Review" %>
+<% end %>
+</div>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -92,10 +92,13 @@
 <div class="show">
   <h2>Reviews</h2>
   <% @shelter.reviews.each do |review| %>
-  <p><img src="<%= review.picture%>" alt="Picture from review" width="200"> </p>
-  <p>Title: <%=review.title%> </p>
-  <p>Rating: <%=review.rating%> </p>
-  <p>Content: <%=review.content%> </p>
-  <p>Username: <%=review.name_of_user%> </p>
+  <section id="review-<%= review.id %>">
+    <p><img src="<%= review.picture%>" alt="Picture from review" width="200"> </p>
+    <p>Title: <%=review.title%> </p>
+    <p>Rating: <%=review.rating%> </p>
+    <p>Content: <%=review.content%> </p>
+    <p>Username: <%=review.name_of_user%> </p>
+    <h5><a href="/shelters/<%= @shelter.id %>/<%="#{review.id}"%>/edit">Edit Review</a></h5>
+  </section>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   get '/shelters/:id/delete', to: 'shelters#destroy'
   get '/shelters/:id/review', to: 'reviews#new'
   post '/shelters/:id/review', to: 'reviews#create'
+  get '/shelters/:id/:id/edit', to: 'reviews#edit'
+  patch '/shelters/:id/review/:review_id', to: 'reviews#update'
   #pets
   get '/pets', to: 'pets#index'
   get '/shelters/:id/pets', to: 'shelterpets#index'

--- a/spec/features/shelters/show_spec.rb
+++ b/spec/features/shelters/show_spec.rb
@@ -78,4 +78,29 @@ RSpec.describe "shelters show page", type: :feature do
     expect(page).to have_content("This place sucks!")
     expect(page).to have_content("Calvin")
   end
+
+  it 'can edit a review' do
+    user_1 = User.create( name: "Austin Powers",
+                              address: "4555 Shag Ave",
+                              city: "Denver",
+                              state: "CO",
+                              zip: 84444,
+                              )
+    shelter_1 = Shelter.create( name: "Sherms Spikey Friends",
+                                address: "1489 Balake Ave.",
+                                city: "Denver",
+                                state: "CO",
+                                zip: "80201",
+                                )
+
+
+    review = Review.create!(shelter_id: shelter_1.id, user_id: user_1.id, title: "Horrible service", rating: 1, content: "I saw a man slap a kitten", picture: "https://felineengineering.com/wp-content/uploads/2019/07/Adorable-sad-kitten-e1562788887775-974x1024.jpg", name_of_user: "Dr. Evil")
+    visit "/shelters/#{shelter_1.id}"
+      within("#review-#{review.id}") do
+        click_on "Edit Review"
+      end
+      fill_in :title, with: "Extremely Horrible Crap Service"
+      click_on "Update Review"
+      expect(page).to have_content("Extremely Horrible Crap Service")
+  end
 end


### PR DESCRIPTION
User Story 7, Edit a Shelter Review

As a visitor,
When I visit a shelter's show page
[x]I see a link to edit the shelter review next to each review.
[x]When I click on this link, I am taken to an edit shelter review path
On this new page, I see a form that includes that review's pre populated data:
[x]- title
[x]- rating
[x]- content
[x]- image
[x]- the name of the user that wrote the review
[x]I can update any of these fields and submit the form.
When the form is submitted, I should return to that shelter's show page
[x]And I can see my updated review