### PR TITLE
Created incomplete field function for review form

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-
+  add_flash_types :info, :error, :warning
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -15,10 +15,15 @@ class ReviewsController < ApplicationController
   end
 
   def update
-    review = Review.find(params[:review_id])
-      review.update(review_params)
-      review.save
-    redirect_to "/shelters/#{review.shelter_id}"
+    @review = Review.find(params[:review_id])
+    @review.update(review_params)
+    if @review.save
+      flash[:notice] = "Review successfully update!"
+      redirect_to "/shelters/#{@review.shelter_id}"
+    else
+      flash[:alert] = "Please fill out all fields to update review."
+      render :edit
+    end
   end
 
   def destroy

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -31,8 +31,8 @@ class SheltersController < ApplicationController
 
   def destroy
     Pet.where(shelter_id: params[:id]).destroy_all
-    shelter = Shelter.find(params[:id])
-    shelter.destroy
+    Review.where(shelter_id: params[:id]).destroy_all
+    Shelter.destroy(params[:id])
     redirect_to '/shelters'
   end
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,5 +1,5 @@
 class Review < ApplicationRecord
   belongs_to :user
   belongs_to :shelter
-  validates_presence_of :title, :rating, :content, :name_of_user
+  validates_presence_of :title, :rating, :content, :name_of_user, :user_id
 end

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -3,23 +3,29 @@
 <%= form_tag "/shelters/#{@review.shelter_id}/review/#{@review.id}", method: :patch do %>
 
 <%= label_tag :title %>
-<%= text_field_tag :title, value="#{@review.title}" %><br>
+<%= text_field_tag :title, value="#{@review.title}", required: true %><br>
 
 <%= label_tag :rating %>
-<%= text_field_tag :rating, value="#{@review.rating}" %><br>
+<%= text_field_tag :rating, value="#{@review.rating}", required: true %><br>
 
 <%= label_tag :content  %>
-<%= text_field_tag :content, value="#{@review.content}" %><br>
+<%= text_field_tag :content, value="#{@review.content}", required: true %><br>
 
 <%= label_tag :picture %>
 <%= text_field_tag :picture, value="#{@review.picture}" %><br>
 
 <%= label_tag :username %>
-<%= text_field_tag :name_of_user, value="#{@review.name_of_user}" %><br>
+<%= text_field_tag :name_of_user, value="#{@review.name_of_user}", required: true %><br>
 
 <%= label_tag :user_id %>
-<%= text_field_tag :user_id, value="#{@review.user_id}" %><br>
+<%= text_field_tag :user_id, value="#{@review.user_id}", required: true %><br>
 
 <%= submit_tag "Update Review" %>
 <% end %>
 </div>
+
+<% flash.each do |type, msg| %>
+<div>
+  <%= msg %>
+</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,3 +28,5 @@ Rails.application.routes.draw do
   get '/users/:id', to: 'users#show'
 
 end
+
+# question: should we change the review delete path to delete

--- a/spec/features/reviews/incomplete_spec.rb
+++ b/spec/features/reviews/incomplete_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "flash notice when form is incomplete", type: :feature do
+  it 'can provide a flash notice' do
+    user_1 = User.create( name: "Austin Powers",
+                              address: "4555 Shag Ave",
+                              city: "Denver",
+                              state: "CO",
+                              zip: 84444,
+                              )
+    shelter_1 = Shelter.create( name: "Sherms Spikey Friends",
+                                address: "1489 Balake Ave.",
+                                city: "Denver",
+                                state: "CO",
+                                zip: "80201",
+                                )
+    review = Review.create!(shelter_id: shelter_1.id, 
+                            user_id: user_1.id, title: "Horrible service", 
+                            rating: 1, content: "I saw a man slap a kitten", 
+                            picture: "https://felineengineering.com/wp-content/uploads/2019/07/Adorable-sad-kitten-e1562788887775-974x1024.jpg", 
+                            name_of_user: "Dr. Evil")
+    visit "/shelters/#{shelter_1.id}"
+      within("#review-#{review.id}") do
+        click_on "Edit Review"
+      end
+      fill_in :title, with: "Extremely Horrible Crap Service"
+      fill_in :rating, with: 0
+      fill_in :content, with: "The goldfish were fighting"
+      fill_in :name_of_user, with: "Cruella Deville"
+      fill_in :user_id, with: ""
+      click_on "Update Review"
+      save_and_open_page
+      expect(page).to have_content("Please fill out all fields to update review.")
+  end
+end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Review, type: :model do
       it { should validate_presence_of :rating }
       it { should validate_presence_of :content }
       it { should validate_presence_of :name_of_user }
+      it { should validate_presence_of :user_id }
     end
 
     describe 'relationships' do


### PR DESCRIPTION
[X] User Story 11, Edit a Shelter Review, Incomplete Form

As a visitor,
When I visit the page to edit a review
And I fail to enter a title, a rating, and/or content in the edit shelter review form, but still try to submit the form
I see a flash message indicating that I need to fill in a title, rating, and content in order to edit a shelter review
And I'm returned to the edit form to edit that review