### PR TITLE
Userstory9edit

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -14,8 +14,13 @@ class SheltersController < ApplicationController
 
   def create
     shelter = Shelter.new(shelter_params)
-    shelter.save
-    redirect_to '/shelters'
+    if shelter.save
+      flash[:notice] = "Shelter successfully update!"
+      redirect_to "/shelters"
+    else
+      flash[:error] = "Please fill out all fields to update review."
+      render :new
+    end
   end
 
   def edit

--- a/spec/features/reviews/incomplete_spec.rb
+++ b/spec/features/reviews/incomplete_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "flash notice when form is incomplete", type: :feature do
       fill_in :name_of_user, with: "Cruella Deville"
       fill_in :user_id, with: ""
       click_on "Update Review"
-      save_and_open_page
+
       expect(page).to have_content("Please fill out all fields to update review.")
   end
 end

--- a/spec/features/shelters/new_spec.rb
+++ b/spec/features/shelters/new_spec.rb
@@ -24,4 +24,17 @@ RSpec.describe "new shelter", type: :feature do
     expect(page).to have_content("Burts Farm Animals")
 
   end
+
+  it "incomplete form sends a flash message" do 
+    visit "/shelters/new"
+
+    fill_in :name, with: ""
+    fill_in :address, with: "87453 Dirt Road #4 "
+    fill_in :city, with: "Longmont"
+    fill_in :state, with: "CO"
+    fill_in :zip, with: "897655"
+    click_button "Create Shelter"
+    
+    expect(page).to have_content("Please fill out all fields to update review.")
+  end
 end


### PR DESCRIPTION
[X ] done

User Story 9, Shelter Review Creation, Incomplete Form

As a visitor,
When I visit the new review page
And I fail to enter a title, a rating, and/or content in the new shelter review form, but still try to submit the form
I see a flash message indicating that I need to fill in a title, rating, and content in order to submit a shelter review
And I'm returned to the new form to create a new review