### PR TITLE
Userstory25

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,13 @@
+class AdminController < ActionController::Base
+  def show
+    @application = Application.find(params[:id])
+  end 
+
+  def approve_pet
+    application = Application.find(params[:id])
+    pet = application.pets.where(id: params[:pet]).first
+    pet.update(status: 'Approved')
+    pet.save
+    redirect_to "/admin/applications/#{application.id}"
+  end
+end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -4,8 +4,8 @@ class ApplicationsController < ApplicationController
     @pets = Pet.all
     @search_results = []
     if params[:search] != '' && !params[:search].nil?
-      @search_results = @pets.where('name like ?', "#{params[:search]}")
-    end
+      @search_results = @pets.where('lower(name) like ?', "%#{params[:search]}%".downcase)
+    end # this is how you do partial search params ^
   end
 
   def user_validation

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,0 +1,12 @@
+<h2>Admin Approval Page</h2>
+<p>Application: <%= @application.id %></p>
+<% @application.pets.each do |pet| %>
+  <section id="pet-<%= pet.id %>">
+    <%= pet.name %><br>
+    <img src="<%= pet.image %>" alt="<%= pet.name %>" width="200"><br>
+    <%= pet.status %>
+    <% if pet.status == 'Adoptable' %>
+      <%= button_to 'Approve', "/admin/applications/#{@application.id}/approve", method: :patch, params: {pet: pet} %>
+    <% end %>
+    </section>
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
   get '/applications/:id', to: 'applications#show'
   patch '/applications/:id', to: 'applications#update'
   patch '/applications/:id/update_pet', to: 'applications#update_pet'
+  # admin
+  get '/admin/applications/:id', to: 'admin#show'
+  patch 'admin/applications/:id/approve', to: 'admin#approve_pet'
 end
 
 # question: should we change the review delete path to delete

--- a/spec/features/admin/show_spec.rb
+++ b/spec/features/admin/show_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Application show page', type: :feature do
+  before(:each) do
+    @user1 = User.create!(name: 'Dr. Evil',
+                          address: '56774 FLower Ave.',
+                          city: 'Smallville',
+                          state: 'Alaska',
+                          zip: 87645)
+    @shelter1 = Shelter.create(name: "Brett's Pet Palace",
+                                address: '456 Sesame Ave',
+                                city: 'Denver',
+                                state: 'CO',
+                                zip: 80222)
+    @pet1 = @shelter1.pets.create!(name: 'Vernon',
+                                    age: 18,
+                                    sex: 'male',
+                                    image: 'vernon.png')
+    @application = @user1.applications.create!(name_of_user: 'Dr. Evil',
+                                      address: '56774 FLower Ave.',
+                                      description: 'I love this hairless cat',
+                                      status: 'In Progress')
+    @application.pets << @pet1
+  end
+
+  it 'can see application info' do
+    visit "admin/applications/#{@application.id}"
+    expect(page).to have_content(@pet1.name)
+    click_on 'Approve'
+    expect(current_path).to eq("/admin/applications/#{@application.id}")
+    within("#pet-#{@pet1.id}") do
+      expect(page).to have_content('Approved')
+    end 
+  end
+end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -95,4 +95,20 @@ RSpec.describe 'Application show page', type: :feature do
     expect(current_path).to eq("/applications/#{@application.id}")
     expect(page).to have_content('Please enter a description.')
   end
+
+  it 'can search using a partial input' do 
+    pet2 = @shelter1.pets.create!(name: 'Bob',
+                                  age: 12,
+                                  sex: 'male')
+    pet3 = @shelter1.pets.create!(name: 'Betsy',
+                                  age: 2,
+                                  sex: 'male')
+    visit "/applications/#{@application.id}"
+    expect(page).to_not have_content("Submit")
+    fill_in :search, with: 'b'
+    click_button 'Search'
+    expect(current_path).to eq("/applications/#{@application.id}")
+    expect(page).to have_content(pet2.name)
+    expect(page).to have_content(pet3.name)
+  end
 end


### PR DESCRIPTION
[x] done

User Story 25, Approving a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to approve the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I approved, I do not see a button to approve this pet
And instead I see an indicator next to the pet that they have been approved