### PR TITLE
Us29

### DIFF
--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -12,5 +12,8 @@
       <%= button_to 'Approve', "/admin/applications/#{@application.id}/approve", method: :patch, params: {pet: pet} %>
       <%= button_to 'Reject', "/admin/applications/#{@application.id}/reject", method: :patch, params: {pet: pet} %>
     <% end %>
+    <% if @application.status == 'Approved' || @application.status == 'Pending' %>
+      <p>This Pet Has Been Approved For Adoption</p>
+    <% end %>
     </section>
   <% end %>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -12,7 +12,7 @@
       <%= button_to 'Approve', "/admin/applications/#{@application.id}/approve", method: :patch, params: {pet: pet} %>
       <%= button_to 'Reject', "/admin/applications/#{@application.id}/reject", method: :patch, params: {pet: pet} %>
     <% end %>
-    <% if @application.status == 'Approved' || @application.status == 'Pending' %>
+    <% if @application.status == 'Approved'  %>
       <p>This Pet Has Been Approved For Adoption</p>
     <% end %>
     </section>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -7,6 +7,9 @@
   <p>Pets: <% @application.pets.each do |pet| %></p>
     <p><%= pet.name %></p>
     <img src="<%= pet.image %>" alt="<%= pet.name %>" width="200">
+    <% if @application.status == 'Pending'  %>
+      <p>This Pet Has Been Approved For Adoption</p>
+    <% end %>
   <% end %>
   <p>Status: <%= @application.status %></p>
 </div>

--- a/spec/features/admin/show_spec.rb
+++ b/spec/features/admin/show_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Application show page', type: :feature do
                                     sex: 'male',
                                     image: 'vernon.png')
     @application.pets << pet2
-    
+
     visit "admin/applications/#{@application.id}"
 
     expect(page).to have_content(@pet1.name)
@@ -82,6 +82,19 @@ RSpec.describe 'Application show page', type: :feature do
     end
     within("#application-status") do
       expect(page).to have_content("Rejected")
+    end
+  end
+
+  it "can see message this pet has been approved for adoption" do
+
+    visit "admin/applications/#{@application.id}"
+
+    expect(page).to have_content(@pet1.name)
+    within("#pet-#{@pet1.id}") do
+      click_on 'Approve'
+    end
+    within("#pet-#{@pet1.id}") do
+      expect(page).to have_content("This Pet Has Been Approved For Adoption")
     end
   end
 


### PR DESCRIPTION
User Story 29, Pets can only have one approved application on them at any time

[x ] done

As a visitor
When a pet has an "Approved" application on them
And when I the pet has a "Pending" application on them
And I visit the admin application show page for pending application
Then next to the pet I do not see a button to approve or reject them
And instead I see a message that this pet has been approved for adoption